### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ This assumes you are running on a Ubuntu system.
 Install some host side utilities
 
 ```
-sudo apt update
-sudo apt install -y \
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
     iperf3 \
     jq \
     hwloc-nox

--- a/prep/qemu/Dockerfile
+++ b/prep/qemu/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:18.04
 
-RUN apt update && \
-    apt install -y \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        apt-utils \
+        ca-certificates \
         build-essential \
         git \
         libtool \
@@ -76,7 +78,7 @@ RUN ./configure \
 
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 
-RUN apt install -y seabios
+RUN apt-get install -y --no-install-recommends seabios
 
 RUN mkdir -p /res/bios && \
     cp x86_64-softmmu/qemu-system-x86_64 /res && \


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
